### PR TITLE
acmepipe: delete temp files

### DIFF
--- a/acme/acmepipe/main.go
+++ b/acme/acmepipe/main.go
@@ -170,10 +170,12 @@ func patchOutput(old, new []byte) error {
 	if err != nil {
 		return err
 	}
+	defer os.Remove(newFile.Name())
 	oldFile, err := tempfile(old)
 	if err != nil {
 		return err
 	}
+	defer os.Remove(oldFile.Name())
 	var stdout, stderr bytes.Buffer
 	cmd := exec.Command("9", "diff", oldFile.Name(), newFile.Name())
 	cmd.Stdout = &stdout


### PR DESCRIPTION
Hi

Here's another small diff for acmepipe.  I had my /tmp filled with acmepipe.* files because temp files were never removed.  This seems to fix it (acmepipe updates the buffers and my /tmp is clean again!)